### PR TITLE
I checked a fix for the missing AndroidManifest.xml issue, please pull it into the master repository if you think it's ok

### DIFF
--- a/apktool-lib/src/main/java/brut/androlib/Androlib.java
+++ b/apktool-lib/src/main/java/brut/androlib/Androlib.java
@@ -77,6 +77,22 @@ public class Androlib {
         new AndrolibJava().decode(apkFile, outDir);
     }
 
+    public void decodeManifestRaw(ExtFile apkFile, File outDir)
+            throws AndrolibException {
+        try {
+            Directory apk = apkFile.getDirectory();
+            LOGGER.info("Copying raw manifest...");
+            apkFile.getDirectory().copyToDir(outDir, APK_MANIFEST_FILENAME);
+        } catch (DirectoryException ex) {
+            throw new AndrolibException(ex);
+        }
+    }
+
+    public void decodeManifestFull(ExtFile apkFile, File outDir)
+            throws AndrolibException {
+        mAndRes.decodeManifest(apkFile, outDir);
+    }
+
     public void decodeResourcesRaw(ExtFile apkFile, File outDir)
             throws AndrolibException {
         try {
@@ -436,5 +452,6 @@ public class Androlib {
         new String[]{"resources.arsc", "AndroidManifest.xml"};
     private final static String[] APP_RESOURCES_FILENAMES =
         new String[]{"AndroidManifest.xml", "res"};
+    private final static String APK_MANIFEST_FILENAME = "AndroidManifest.xml";
     private final static String VERSION = "1.3.2";
 }

--- a/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
+++ b/apktool-lib/src/main/java/brut/androlib/ApkDecoder.java
@@ -89,6 +89,7 @@ public class ApkDecoder {
                     break;
             }
         }
+
         if (hasResources()) {
             switch (mDecodeResources) {
                 case DECODE_RESOURCES_NONE:
@@ -99,7 +100,21 @@ public class ApkDecoder {
                         getResTable());
                     break;
             }
+        } else {
+            // if there's no resources.asrc, decode the manifest without looking up
+            // attribute references
+            if (hasManifest()) {
+                switch (mDecodeResources) {
+                case DECODE_RESOURCES_NONE:
+                    mAndrolib.decodeManifestRaw(mApkFile, outDir);
+                    break;
+                case DECODE_RESOURCES_FULL:
+                    mAndrolib.decodeManifestFull(mApkFile, outDir);
+                    break;
+                }
+            }
         }
+
         mAndrolib.decodeRawFiles(mApkFile, outDir);
         writeMetaFile();
     }
@@ -154,6 +169,14 @@ public class ApkDecoder {
     public boolean hasSources() throws AndrolibException {
         try {
             return mApkFile.getDirectory().containsFile("classes.dex");
+        } catch (DirectoryException ex) {
+            throw new AndrolibException(ex);
+        }
+    }
+
+    public boolean hasManifest() throws AndrolibException {
+        try {
+            return mApkFile.getDirectory().containsFile("AndroidManifest.xml");
         } catch (DirectoryException ex) {
             throw new AndrolibException(ex);
         }

--- a/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
+++ b/apktool-lib/src/main/java/brut/androlib/res/AndrolibResources.java
@@ -97,6 +97,27 @@ final public class AndrolibResources {
         return pkg;
     }
 
+    public void decodeManifest(ExtFile apkFile, File outDir)
+            throws AndrolibException {
+
+        Duo<ResFileDecoder, AXmlResourceParser> duo = getManifestFileDecoder();
+        ResFileDecoder fileDecoder = duo.m1;
+
+        Directory inApk, out;
+        try {
+            inApk = apkFile.getDirectory();
+            out = new FileDirectory(outDir);
+
+            LOGGER.info("Decoding AndroidManifest.xml without resources...");
+            fileDecoder.decode(
+                inApk, "AndroidManifest.xml", out, "AndroidManifest.xml",
+                "xml");
+
+        } catch (DirectoryException ex) {
+            throw new AndrolibException(ex);
+        }
+    }
+
     public void decode(ResTable resTable, ExtFile apkFile, File outDir)
             throws AndrolibException {
         Duo<ResFileDecoder, AXmlResourceParser> duo = getResFileDecoder();
@@ -111,6 +132,7 @@ final public class AndrolibResources {
             inApk = apkFile.getDirectory();
             out = new FileDirectory(outDir);
 
+            LOGGER.info("Decoding AndroidManifest.xml with resources...");
             fileDecoder.decode(
                 inApk, "AndroidManifest.xml", out, "AndroidManifest.xml",
                 "xml");
@@ -231,6 +253,19 @@ final public class AndrolibResources {
 
         AXmlResourceParser axmlParser = new AXmlResourceParser();
         axmlParser.setAttrDecoder(new ResAttrDecoder());
+        decoders.setDecoder("xml",
+            new XmlPullStreamDecoder(axmlParser, getResXmlSerializer()));
+
+        return new Duo<ResFileDecoder, AXmlResourceParser>(
+            new ResFileDecoder(decoders), axmlParser);
+    }
+
+    public Duo<ResFileDecoder, AXmlResourceParser> getManifestFileDecoder() {
+        ResStreamDecoderContainer decoders =
+            new ResStreamDecoderContainer();
+
+        AXmlResourceParser axmlParser = new AXmlResourceParser();
+
         decoders.setDecoder("xml",
             new XmlPullStreamDecoder(axmlParser, getResXmlSerializer()));
 

--- a/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
+++ b/apktool-lib/src/main/java/brut/androlib/res/decoder/AXmlResourceParser.java
@@ -325,6 +325,10 @@ public class AXmlResourceParser implements XmlResourceParser {
                     valueData
                 ), ex);
             }
+        } else {
+            if (valueType==TypedValue.TYPE_STRING) {
+                return m_strings.getString(valueRaw);
+            }
         }
 
         return TypedValue.coerceToString(valueType, valueData);
@@ -370,7 +374,7 @@ public class AXmlResourceParser implements XmlResourceParser {
     public String getAttributeValue(String namespace, String attribute) {
         int index = findAttribute(namespace, attribute);
         if (index == -1) {
-            return null;
+            return "";
         }
         return getAttributeValue(index);
     }


### PR DESCRIPTION
fix for issue #61: AndroidManifest.xml is missed in the decoded folder of some packages

see: http://code.google.com/p/android-apktool/issues/detail?id=61

This fix allows AXmlResourceParser to work without an AttrDecoder. If there is no AttrDecoder specified, it dumps attribute strings directly without looking them up in the resource database.

If there is a resources.asrc in the APK, the AndroidManifest.xml file gets parsed like it did before. If there isn't one, it gets parsed without an AttrDecoder.
